### PR TITLE
Transfer unused props onto returned component

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A React Component To make live editable demos of other React Components. Great f
 * `props` - an object with the props for the component (these will be editable)
 * `codeContainerStyle` - optional prop to edit style of code container
 * `componentContainerStyle` - optional prop to edit style of component container
+* Any other props will be transferred to the root element
 
 ```jsx
 import React from 'react';
@@ -34,7 +35,7 @@ function TestComponent({ backgroundColor, color, height }) {
 
 function Demo() {
   return (
-    <ComponentDemo 
+    <ComponentDemo
       Component={TestComponent}
       name='TestComponent'
       props={{

--- a/src/index.js
+++ b/src/index.js
@@ -42,13 +42,13 @@ export default class ComponentDemo extends React.Component {
   }
 
   render() {
-    const { Component, name, codeContainerStyle, componentContainerStyle } = this.props;
+    const { Component, name, codeContainerStyle, componentContainerStyle, ...rest } = this.props;
     const codeString = `${Object.keys(this.state).reduce((codeString, prop) => (
       codeString + `\n  ${prop}={${JSON.stringify(this.state[prop])}}`
     ), `<${name}`)}\n/>`;
 
     return (
-      <div>
+      <div {...rest}>
         <div ref={node => this.node = node}>
           <SyntaxHighlighter language="javascript" style={rainbow} customStyle={codeContainerStyle || {}}>
             {codeString}


### PR DESCRIPTION
I'm spesifically after being able to style the wrapper with the standard style prop.

This approach will pass on any unused props to the wrapping div. The technique is explained in more detail [here](http://reactjs.cn/react/docs/transferring-props.html#rest-and-spread-properties-...).